### PR TITLE
adds grant_type to refresh token request's payload

### DIFF
--- a/addon/authenticators/jwt.js
+++ b/addon/authenticators/jwt.js
@@ -212,7 +212,7 @@ export default TokenAuthenticator.extend({
     @return {object} An object with the nested property name.
   */
   makeRefreshData(refreshToken) {
-    const data = {};
+    const data = {grant_type: 'refresh_token'};
     const nestings = this.refreshTokenPropertyName.split('.');
     const refreshTokenPropertyName = nestings.pop();
     let lastObject = data;


### PR DESCRIPTION
Add `grant_type=refresh_token` to the post request.
It seems `grant_type` is mandatory for some backends.
See : 
[https://github.com/alvarosanchez/grails-spring-security-rest/blob/ffa848c9c6dd82f92f2ab489cb5d7a1515c587f2/spring-security-rest/grails-app/controllers/grails/plugin/springsecurity/rest/RestOauthController.groovy#L123](https://github.com/alvarosanchez/grails-spring-security-rest/blob/ffa848c9c6dd82f92f2ab489cb5d7a1515c587f2/spring-security-rest/grails-app/controllers/grails/plugin/springsecurity/rest/RestOauthController.groovy#L123)